### PR TITLE
Update calendar.tsv

### DIFF
--- a/calendar.tsv
+++ b/calendar.tsv
@@ -3,7 +3,7 @@ isOver	title	series	month	day	year	ends	location	country	website	twitter
 	Programming Language Design and Implementation 2019	PLDI	June	15	2020	6/20/20	Royal Geographical Society, London, UK	UK	https://conf.researchr.org/home/pldi-2020	
 	History of Programming Languages IV	HOPL	June	14	2020	6/16/20	Royal Geographical Society, London, UK	UK	https://hopl4.sigplan.org/	
 	Systems, Programming, Languages and Applications: Software for Humanity 2019	SPLASH	October	20	2019	10/25/19	Athens, Greece	Greece	https://conf.researchr.org/home/splash-2019	
-	Strange Loop 2019	StangeLoop	September	12	2019	9/14/19	Stifel Theatre, St. Louis, MO, USA	USA	https://www.thestrangeloop.com/	
+x	Strange Loop 2019	StangeLoop	September	12	2019	9/14/19	Stifel Theatre, St. Louis, MO, USA	USA	https://www.thestrangeloop.com/	
 x	International Conference on Functional Programming 2019	ICFP	August	19	2019	8/21/19	Berlin, Germany	Germany	https://icfp19.sigplan.org/	
 x	Second International Summer School on Metaprogramming	ISSMP	August	11	2019	8/16/19	Schloss Dagstuhl, Germany	Germany	https://www.cl.cam.ac.uk/events/metaprog/2019/	
 x	Balisage: The Markup Conference 2019	Balisage	July	29	2019	8/2/19	Rockville, Maryland, USA	USA	http://www.balisage.net/	


### PR DESCRIPTION
The ``Strange Loop 2019`` event is now over since it now AFTER September 12th, 2019; marked and changed accordingly.