### PR TITLE
Update nim.lani

### DIFF
--- a/database/nim.lani
+++ b/database/nim.lani
@@ -1,4 +1,4 @@
-appeared 2008
+appeared 2004
 type pl
 creators Andreas Rumpf
 website https://nim-lang.org/


### PR DESCRIPTION
The language was created in 2004:
* says this article here: http://nimrod-lang.org/
* says Andreas Rump himself: https://irclogs.nim-lang.org/01-07-2012.html

It would be also good to note that it was called Nimrod until 2014.