### PR TITLE
Update felix-programming-language.lani

### DIFF
--- a/database/felix-programming-language.lani
+++ b/database/felix-programming-language.lani
@@ -1,3 +1,4 @@
-appeared 1999
+appeared 2001
 type pl
-wikipedia Felix_%28programming_language%29
+website http://felix-lang.github.io/felix/
+github https://github.com/felix-lang/felix


### PR DESCRIPTION
The language was initially developed on sourceforge, it has oldest commit from 2001. Also mail lists start in 2001.

The old website does not exist anymore.

The language is still being developed by its author, John Skaller.

The page  https://codelani.com/languages/felix.html
points to the same language and should be dropped (or this one).